### PR TITLE
fix(paws-data-pipeline): quote ingress annotation value

### DIFF
--- a/paws-data-pipeline/release-values.yaml
+++ b/paws-data-pipeline/release-values.yaml
@@ -4,7 +4,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/proxy-body-size: '50m'
-    nginx.ingress.kubernetes.io/proxy-read-timeout: 300
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
   hosts:
     - host: paws-data-pipeline.sandbox.k8s.phl.io
       paths: [ '/' ]


### PR DESCRIPTION
@c-simpson I found a validation error in our application of paws-dp's ingress, I don't think the proxy-read-timeout was getting applied as we had a number but according to the top of [this page](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) all ingress-nginx annotation values must be strings, so things that look like numbers to YAML have to be manually quoted like this