### PR TITLE
Add NODE_OPTIONS environment variable with memory limit to prevent OO…

### DIFF
--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -44,6 +44,8 @@ app:
           name: linode-storage
           key: LINODE_ENDPOINT_URL
           optional: false
+    - name: NODE_OPTIONS
+      value: "--openssl-legacy-provider --max-old-space-size=768"
 
 # Resource settings for the application
 resources:


### PR DESCRIPTION

This pull request introduces a configuration change to the `choose-native-plants/release-values.yaml` file to enhance the application's runtime behavior.

Configuration changes:

* [`choose-native-plants/release-values.yaml`](diffhunk://#diff-5792d0f10a00ff40bd8f2ab47da2c3b64d7f0a2737107b580e9ff93d6f9c356aR47-R48): Added a new environment variable `NODE_OPTIONS` with the value `"--openssl-legacy-provider --max-old-space-size=768"`. This change likely addresses compatibility issues with OpenSSL and optimizes memory usage.