### PR TITLE
Add events access to deployment-admin role to allow viewing Kubernete…

### DIFF
--- a/admins/choose-native-plants.yaml
+++ b/admins/choose-native-plants.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: choose-native-plants
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "configmaps", "secrets", "persistentvolumeclaims"]
+  resources: ["pods", "services", "configmaps", "secrets", "persistentvolumeclaims", "events"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]
   resources: ["pods/exec", "pods/portforward", "pods/log"]


### PR DESCRIPTION

This pull request updates the resource permissions in the `admins/choose-native-plants.yaml` file to include an additional resource type.

Permissions update:

* [`admins/choose-native-plants.yaml`](diffhunk://#diff-9c2f68020ca88b8bd9420500efd5a823e646621cdb9478330c250fc6258474e9L23-R23): Added `events` to the list of resources allowed for operations such as `get`, `list`, `watch`, `create`, `update`, `patch`, and `delete`.