### PR TITLE
Remove existingPVCs configuration to allow automatic PVC creation in …

### DIFF
--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -54,14 +54,11 @@ resources:
   requests:
     memory: 1Gi
 
-# Use existing resources instead of creating new ones
-existingPVCs:
-  appImages: "choose-native-plants-app-images-v2"
-  mongoData: "choose-native-plants-mongo-data"
+# Allow the Helm chart to create PVCs automatically
+# (removed existingPVCs configuration)
 
-# Use existing service and ingress
-existingService: false
-existingIngress: false
+# Allow the Helm chart to create Service and Ingress resources automatically
+# (removed existingService and existingIngress configuration)
 
 ingress:
   enabled: true


### PR DESCRIPTION
…sandbox
This pull request modifies the Helm chart configuration in `choose-native-plants/release-values.yaml` to simplify resource management by allowing the chart to create resources automatically. The most important changes involve removing configurations for existing resources and enabling automatic creation.

Resource management simplifications:

* Removed the `existingPVCs` configuration, which previously specified pre-existing PersistentVolumeClaims (`appImages` and `mongoData`). The chart will now create PVCs automatically.
* Removed the `existingService` and `existingIngress` configurations. The chart will now automatically create Service and Ingress resources.