### PR TITLE
Update release-values.yaml for 2.0.5 release and fix duplicate env issue

### DIFF
--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -1,49 +1,7 @@
 app:
   image:
-    tag: "2.0.4"
+    tag: "2.0.5"
   env:
-    - name: PAC_API_BASE_URL
-      valueFrom:
-        secretKeyRef:
-          name: pac-api
-          key: PAC_API_BASE_URL
-          optional: false
-    - name: PAC_API_KEY
-      valueFrom:
-        secretKeyRef:
-          name: pac-api
-          key: PAC_API_KEY
-          optional: false
-    - name: AWS_ACCESS_KEY_ID
-      valueFrom:
-        secretKeyRef:
-          name: linode-storage
-          key: AWS_ACCESS_KEY_ID
-          optional: false
-    - name: AWS_SECRET_ACCESS_KEY
-      valueFrom:
-        secretKeyRef:
-          name: linode-storage
-          key: AWS_SECRET_ACCESS_KEY
-          optional: false
-    - name: AWS_DEFAULT_REGION
-      valueFrom:
-        secretKeyRef:
-          name: linode-storage
-          key: AWS_DEFAULT_REGION
-          optional: false
-    - name: LINODE_BUCKET_NAME
-      valueFrom:
-        secretKeyRef:
-          name: linode-storage
-          key: LINODE_BUCKET_NAME
-          optional: false
-    - name: LINODE_ENDPOINT_URL
-      valueFrom:
-        secretKeyRef:
-          name: linode-storage
-          key: LINODE_ENDPOINT_URL
-          optional: false
     - name: NODE_OPTIONS
       value: "--openssl-legacy-provider --max-old-space-size=768"
 


### PR DESCRIPTION
This pull request updates the application image version and removes several environment variable configurations from the `release-values.yaml` file.

Key changes:

### Version Update:
* Updated the application image tag from `2.0.4` to `2.0.5`.

### Configuration Cleanup:
* Removed environment variable configurations for `PAC_API_BASE_URL`, `PAC_API_KEY`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `LINODE_BUCKET_NAME`, and `LINODE_ENDPOINT_URL`, which were previously sourced from Kubernetes secrets.