### PR TITLE
feat: implement Flux image update automation for balancer

### DIFF
--- a/balancer/kustomization.yaml
+++ b/balancer/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 
 images:
   - name: ghcr.io/codeforphilly/balancer-main/app
-    newTag: "1.1.3"
+    newTag: "1.1.3" # {"$imagepolicy": "flux-system:balancer"}
 
 patches:
   - target:

--- a/flux-automation.yaml
+++ b/flux-automation.yaml
@@ -1,0 +1,48 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: balancer
+  namespace: flux-system
+spec:
+  image: ghcr.io/codeforphilly/balancer-main/app
+  interval: 1h
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: balancer
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: balancer
+  filterSelection:
+    pattern: '^dev-[0-9]+-[a-f0-9]+'
+  policy:
+    alphabetical:
+      order: asc # asc will pick the highest alphabetical value, which is the newest timestamp.
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: balancer-updates
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: 'App: balancer image update to {{ .SelectedTarget.Tag }}'
+    push:
+      branch: main
+  update:
+    path: ./balancer
+    strategy: Setters

--- a/flux-automation.yaml
+++ b/flux-automation.yaml
@@ -15,11 +15,9 @@ metadata:
 spec:
   imageRepositoryRef:
     name: balancer
-  filterSelection:
-    pattern: '^dev-[0-9]+-[a-f0-9]+'
   policy:
-    alphabetical:
-      order: asc # asc will pick the highest alphabetical value, which is the newest timestamp.
+    semver:
+      range: '>=1.2.0-0' # Includes pre-releases like 1.2.0-dev.TIMESTAMP
 
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta1

--- a/flux-automation.yaml
+++ b/flux-automation.yaml
@@ -15,9 +15,11 @@ metadata:
 spec:
   imageRepositoryRef:
     name: balancer
+  filterSelection:
+    pattern: '^.*-dev\.[0-9]+$'
   policy:
-    semver:
-      range: '>=1.2.0-0' # Includes pre-releases like 1.2.0-dev.TIMESTAMP
+    alphabetical:
+      order: desc # Picks the highest alphabetical/numerical value (newest timestamp)
 
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta1


### PR DESCRIPTION
This PR implements Flux Image Update Automation for the `balancer` application.

Depends on: #124
Related to: [CodeForPhilly/balancer-main#455](https://github.com/CodeForPhilly/balancer-main/pull/455)

### Changes:
1.  **`balancer/kustomization.yaml`**: Added the Flux automation marker `# {"$imagepolicy": "flux-system:balancer"}` to the image tag.
2.  **`flux-automation.yaml`**: Created new Flux resources:
    *   `ImageRepository`: Monitors `ghcr.io/codeforphilly/balancer-main/app`.
    *   `ImagePolicy`: Configured to automatically pick the latest **development build** (tags matching `.*-dev.[0-9]+`). It uses alphabetical sorting to ensure the latest timestamp is chosen.
    *   `ImageUpdateAutomation`: Automatically commits image tag updates back to this repository.

### Requirements:
*   Flux v2 with Image Reflector and Automation controllers must be installed.
*   The cluster must have write access to this repository.