### PR TITLE
feat: track develop branch for balancer manifests

### DIFF
--- a/.holo/sources/balancer.toml
+++ b/.holo/sources/balancer.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/CodeForPhilly/balancer-main.git"
-ref = "refs/heads/main"
+ref = "refs/heads/develop"


### PR DESCRIPTION
This PR updates the balancer holosource to track the develop branch of the app repository instead of main. This ensures that the sandbox cluster accurately reflects the latest manifest and configuration changes from the develop branch.