### PR TITLE
feat: migrate echo-http to envoy gateway

### DIFF
--- a/echo-http.yaml
+++ b/echo-http.yaml
@@ -46,27 +46,22 @@ spec:
 
 ---
 
-kind: Ingress
-apiVersion: networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: echo-http
   namespace: echo-http
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    kubernetes.io/ingress.class: nginx
 spec:
-  tls:
-    - hosts:
-        - echo-http.sandbox.k8s.phl.io
-      secretName: echo-http-tls
+  parentRefs:
+    - name: main-gateway
+      namespace: envoy-gateway-system
+  hostnames:
+    - echo-http.sandbox.k8s.phl.io
   rules:
-    - host: echo-http.sandbox.k8s.phl.io
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: echo-http
-                port:
-                  number: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: echo-http
+          port: 80


### PR DESCRIPTION
## Changes
- Migrate `echo-http` service to Gateway API (HTTPRoute)

Depends on: https://github.com/CodeForPhilly/cfp-sandbox-cluster/pull/131