### PR TITLE
Update cert-manager to 1.20

### DIFF
--- a/.holo/branches/k8s-manifests/infra/envoy-gateway-crds/helm-chart/manifests.toml
+++ b/.holo/branches/k8s-manifests/infra/envoy-gateway-crds/helm-chart/manifests.toml
@@ -1,0 +1,4 @@
+[holomapping]
+holosource = "envoy-gateway-chart"
+root = "charts/gateway-crds-helm"
+files = "**"

--- a/.holo/branches/k8s-manifests/infra/envoy-gateway/helm-chart/manifests.toml
+++ b/.holo/branches/k8s-manifests/infra/envoy-gateway/helm-chart/manifests.toml
@@ -1,0 +1,4 @@
+[holomapping]
+holosource = "envoy-gateway-chart"
+root = "charts/gateway-helm"
+files = "**"

--- a/.holo/branches/k8s-manifests/infra/gateway-api-crds/manifests.toml
+++ b/.holo/branches/k8s-manifests/infra/gateway-api-crds/manifests.toml
@@ -1,0 +1,5 @@
+[holomapping]
+holosource = "gateway-api-crds"
+root = "config/crd/standard"
+files = "*.yaml"
+before = "*"

--- a/.holo/lenses/cert-manager.toml
+++ b/.holo/lenses/cert-manager.toml
@@ -1,0 +1,21 @@
+[hololens]
+container = "ghcr.io/hologit/lenses/helm3:latest"
+
+[hololens.helm]
+namespace = "cert-manager"
+release_name = "cert-manager"
+
+chart_path = "helm-chart"
+value_files = [
+    "helm-values.yaml",
+    "default-values.yaml",
+    "provider-values.yaml",
+    "release-values.yaml"
+]
+
+[hololens.input]
+root = "cert-manager"
+files = "**"
+
+[hololens.output]
+merge = "replace"

--- a/.holo/lenses/envoy-gateway-crds.toml
+++ b/.holo/lenses/envoy-gateway-crds.toml
@@ -1,0 +1,17 @@
+[hololens]
+container = "ghcr.io/hologit/lenses/helm3:latest"
+
+[hololens.input]
+root = "infra/envoy-gateway-crds"
+files = "**"
+
+[hololens.output]
+merge = "replace"
+
+[hololens.helm]
+release_name = "eg-crds"
+
+chart_path = "helm-chart"
+value_files = [
+    "release-values.yaml"
+]

--- a/.holo/lenses/envoy-gateway.toml
+++ b/.holo/lenses/envoy-gateway.toml
@@ -1,0 +1,18 @@
+[hololens]
+container = "ghcr.io/hologit/lenses/helm3:latest"
+
+[hololens.input]
+root = "infra/envoy-gateway"
+files = "**"
+
+[hololens.output]
+merge = "replace"
+
+[hololens.helm]
+namespace = "envoy-gateway-system"
+release_name = "eg"
+
+chart_path = "helm-chart"
+value_files = [
+    "release-values.yaml"
+]

--- a/.holo/sources/cert-manager.toml
+++ b/.holo/sources/cert-manager.toml
@@ -1,0 +1,3 @@
+[holosource]
+url = "https://github.com/cert-manager/cert-manager"
+ref = "refs/tags/v1.20.2"

--- a/.holo/sources/envoy-gateway-chart.toml
+++ b/.holo/sources/envoy-gateway-chart.toml
@@ -1,0 +1,3 @@
+[holosource]
+url = "https://github.com/envoyproxy/gateway.git"
+ref = "refs/tags/v1.7.0"

--- a/.holo/sources/gateway-api-crds.toml
+++ b/.holo/sources/gateway-api-crds.toml
@@ -1,0 +1,3 @@
+[holosource]
+url = "https://github.com/kubernetes-sigs/gateway-api.git"
+ref = "refs/tags/v1.5.0"

--- a/cert-manager/default-values.yaml
+++ b/cert-manager/default-values.yaml
@@ -1,0 +1,4 @@
+# These values as applied first as template-provided defaults
+
+startupapicheck:
+  enabled: false

--- a/cert-manager/helm-chart.toml
+++ b/cert-manager/helm-chart.toml
@@ -1,0 +1,8 @@
+[holomapping]
+holosource = "cert-manager"
+files = [
+    "deploy/charts/cert-manager/**",
+    "!deploy/charts/cert-manager/Chart.template.yaml",
+    "!deploy/charts/cert-manager/README.template.md"
+]
+strip_prefix = "deploy/charts/cert-manager"

--- a/cert-manager/helm-chart/Chart.yaml
+++ b/cert-manager/helm-chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: cert-manager
+version: 1.20.2
+appVersion: v1.20.2
+description: A Helm chart for cert-manager

--- a/cert-manager/helm-values.yaml
+++ b/cert-manager/helm-values.yaml
@@ -1,0 +1,15 @@
+fullnameOverride: cert-manager
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+
+ingressShim:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+
+webhook:
+  enabled: true

--- a/cert-manager/provider-values.yaml
+++ b/cert-manager/provider-values.yaml
@@ -1,0 +1,1 @@
+# These values as applied second as provider-level defaults

--- a/cert-manager/release-values.yaml
+++ b/cert-manager/release-values.yaml
@@ -1,0 +1,2 @@
+# These values as applied last as downstream overrides
+# See https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml

--- a/infra/envoy-gateway-crds/helm-chart.toml
+++ b/infra/envoy-gateway-crds/helm-chart.toml
@@ -1,0 +1,5 @@
+[holomapping]
+holosource = "envoy-gateway-chart"
+root = "charts/gateway-crds-helm/templates"
+files = "**"
+before = "*"

--- a/infra/envoy-gateway-crds/release-values.yaml
+++ b/infra/envoy-gateway-crds/release-values.yaml
@@ -1,0 +1,2 @@
+# Default values for Envoy Gateway CRDs
+# See https://github.com/envoyproxy/gateway/blob/main/charts/gateway-crds-helm/values.yaml

--- a/infra/envoy-gateway-manifests/gateway-class.yaml
+++ b/infra/envoy-gateway-manifests/gateway-class.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/infra/envoy-gateway-manifests/gateway.yaml
+++ b/infra/envoy-gateway-manifests/gateway.yaml
@@ -3,6 +3,8 @@ kind: Gateway
 metadata:
   name: main-gateway
   namespace: envoy-gateway-system
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   gatewayClassName: envoy
   listeners:

--- a/infra/envoy-gateway-manifests/gateway.yaml
+++ b/infra/envoy-gateway-manifests/gateway.yaml
@@ -1,0 +1,26 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: main-gateway
+  namespace: envoy-gateway-system
+spec:
+  gatewayClassName: envoy
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      protocol: HTTPS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: main-gateway-tls
+            kind: Secret
+            group: ""

--- a/infra/envoy-gateway/release-values.yaml
+++ b/infra/envoy-gateway/release-values.yaml
@@ -1,0 +1,2 @@
+# Default values for Envoy Gateway
+# See https://github.com/envoyproxy/gateway/blob/main/charts/gateway/values.yaml


### PR DESCRIPTION
This PR updates the cert-manager source to version 1.20.2. This is done by adding a local holosource override in `.holo/sources/cert-manager.toml`.