### PR TITLE
fix(holo): restore k8s-manifests projection (cnpg + balancer)

### DIFF
--- a/.holo/branches/k8s-manifests/balancer/manifests.toml
+++ b/.holo/branches/k8s-manifests/balancer/manifests.toml
@@ -1,4 +1,4 @@
 [holomapping]
 holosource = "balancer"
-root = "deploy/manifests/balancer"
+root = "deploy/manifests/balancer/base"
 files = "**"

--- a/.holo/branches/k8s-manifests/infra/cloudnative-pg/_cfp-sandbox-cluster.toml
+++ b/.holo/branches/k8s-manifests/infra/cloudnative-pg/_cfp-sandbox-cluster.toml
@@ -1,1 +1,0 @@
-# include in cfp-sandbox-cluster

--- a/.holo/lenses/cloudnative-pg.toml
+++ b/.holo/lenses/cloudnative-pg.toml
@@ -1,0 +1,14 @@
+[hololens]
+container = "ghcr.io/hologit/lenses/helm3:latest"
+
+[hololens.input]
+root = "infra/cloudnative-pg/operator"
+files = "**"
+
+[hololens.output]
+merge = "replace"
+
+[hololens.helm]
+namespace = "cloudnative-pg"
+release_name = "cloudnative-pg"
+include_crds = true

--- a/.holo/sources/balancer.toml
+++ b/.holo/sources/balancer.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/CodeForPhilly/balancer-main.git"
-ref = "refs/heads/develop"
+ref = "refs/tags/v1.1.3"

--- a/.holo/sources/cloudnative-pg-chart.toml
+++ b/.holo/sources/cloudnative-pg-chart.toml
@@ -1,3 +1,3 @@
 [holosource]
-url = "https://github.com/cloudnative-pg/cloudnative-pg.git"
-ref = "refs/tags/v1.25.0"
+url = "https://github.com/cloudnative-pg/charts.git"
+ref = "refs/tags/cloudnative-pg-v0.23.1"

--- a/balancer/kustomization.yaml
+++ b/balancer/kustomization.yaml
@@ -4,7 +4,10 @@ kind: Kustomization
 namespace: balancer
 
 resources:
-  - manifests/overlays/sandbox
+  - manifests/namespace.yaml
+  - manifests/deployment.yaml
+  - manifests/service.yaml
+  - manifests/ingress.yaml
 
 images:
   - name: ghcr.io/codeforphilly/balancer-main/app
@@ -27,3 +30,10 @@ patches:
       - op: replace
         path: /spec/rules/0/host
         value: sandbox.balancerproject.org
+  - target:
+      kind: Namespace
+      name: balancer
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: dev


### PR DESCRIPTION
## Summary

Restores `Build k8s-manifests` end-to-end. Main has been broken since #129 (balancer source drift, 2mo ago) and #135 added two more failure points on top. This PR fixes all three:

1. **Balancer source pinned to a stable tag** (`0ffe275f` — Chris) — `.holo/sources/balancer.toml` now tracks `refs/tags/v1.1.3` instead of mutable `refs/heads/develop`, and `balancer/kustomization.yaml` reverted to match. Stops the kustomize-lens from breaking on upstream drift.
2. **Empty holomapping deleted** (`32642b26`) — `.holo/branches/k8s-manifests/infra/cloudnative-pg/_cfp-sandbox-cluster.toml` had only a comment, no `[holomapping]` section. Hologit aborted with `holomapping config not found`. The root `_cfp-sandbox-cluster.toml` already pulls `infra/cloudnative-pg/*.yaml` from the workspace via `**`, so the nested file is redundant.
3. **Helm source repo corrected** (`32642b26`) — `.holo/sources/cloudnative-pg-chart.toml` pointed at `cloudnative-pg/cloudnative-pg.git` (the operator's Go source), which has no `charts/cloudnative-pg/` path. The chart actually lives at `cloudnative-pg/charts.git`. Repinned to tag `cloudnative-pg-v0.23.1` (chart appVersion `1.25.0`, matching #135's stated operator version).
4. **helm3 lens added for cnpg** (`f242c504`) — #135 projected the chart but configured no lens to render it, so `k8s-normalize` choked on the chart's `Chart.yaml` (which has no `kind`). Added `.holo/lenses/cloudnative-pg.toml` scoped to `infra/cloudnative-pg/operator` so the workspace YAMLs at `infra/cloudnative-pg/` aren't replaced. Sets `include_crds = true` since cnpg ships CRDs in the chart.

## Verification

End-to-end `git holo project k8s-manifests-github` succeeds locally and produces the tree this PR's CI also produced. Diff against the currently deployed `releases/k8s-manifests` shows:

- **Cluster-scoped (`_/`):** Namespace, ClusterRole `cloudnative-pg` + aggregated `cloudnative-pg-edit`/`cloudnative-pg-view`, ClusterRoleBinding, all 9 CRDs (`backups`/`clusterimagecatalogs`/`clusters`/`databases`/`imagecatalogs`/`poolers`/`publications`/`scheduledbackups`/`subscriptions`), Mutating + Validating WebhookConfigurations.
- **In `cloudnative-pg/` namespace:** operator Deployment (image `ghcr.io/cloudnative-pg/cloudnative-pg:1.25.0`, ServiceAccount `cloudnative-pg`), webhook Service (`cnpg-webhook-service`, ClusterIP:443→webhook-server, selector matches Deployment), ServiceAccount, controller-manager-config + default-monitoring ConfigMaps, `Cluster/shared-cluster` from the workspace YAML.
- **No leakage:** no `Chart.yaml`, `_helpers.tpl`, `values.yaml`, or template files reach the projection — the helm3 lens fully consumed and replaced its input scope.
- **Wiring sanity-checked:** ClusterRoleBinding subject → ServiceAccount in correct namespace; webhook configs reference `cnpg-webhook-service` in `cloudnative-pg`; operator's ClusterRole has `admissionregistration.k8s.io` `get`/`patch` so it can self-inject `caBundle`; `cnpg-webhook-cert` Secret is mounted `optional: true` (operator self-bootstraps it on startup — standard cnpg pattern).

The only non-cnpg/balancer change in the diff is `paws-data-pipeline/Deployment` image tag `2.63` → `2.64`, which is incidental upstream chart movement (paws-data-pipeline source is on a branch ref).

## Things to verify post-deploy (not blockers)

- **`shared_preload_libraries: vector` with `imageName: ghcr.io/cloudnative-pg/postgresql:16.1`** — the standard cnpg postgresql image may not include pgvector. If cluster pods crash-loop on startup, switch to a pgvector-enabled image variant (e.g. `ghcr.io/cloudnative-pg/postgresql-trunk:...` or a custom build).
- **`balancer-db-credentials` Secret** — referenced by the Cluster CR's `managed.roles` but not in this projection. Expected to come from the balancer app's deploy / a SealedSecret elsewhere. Cluster will start fine; the managed role just won't apply until the Secret exists.
- **No PodMonitor** — chart provides `templates/podmonitor.yaml` gated on `monitoring.podMonitorEnabled`. Add a `release-values.yaml` with monitoring overrides if Prometheus integration is wanted.

## Test plan

- [ ] `Build k8s-manifests` workflow succeeds on merge
- [ ] `K8s: Prepare k8s-manifests Deploy PR` action opens a PR with the cnpg additions
- [ ] After deploy, `cloudnative-pg` operator pod becomes `Ready` (will self-create `cnpg-webhook-cert` Secret on first run)
- [ ] `kubectl get crd | grep cnpg` shows all 9 CRDs
- [ ] `Cluster/shared-cluster` in `cloudnative-pg` namespace reaches `Cluster in healthy state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)