### PR TITLE
fix(cnpg): use PG 18 PostGIS+pgvector image on shared-cluster

### DIFF
--- a/.holo/sources/cloudnative-pg-chart.toml
+++ b/.holo/sources/cloudnative-pg-chart.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/cloudnative-pg/charts.git"
-ref = "refs/tags/cloudnative-pg-v0.23.1"
+ref = "refs/tags/cloudnative-pg-v0.28.0"

--- a/infra/cloudnative-pg/shared-cluster.yaml
+++ b/infra/cloudnative-pg/shared-cluster.yaml
@@ -5,17 +5,13 @@ metadata:
   namespace: cloudnative-pg
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.1
+  imageName: ghcr.io/cloudnative-pg/postgis:18-3-system-trixie
   storage:
     size: 20Gi
-  
+
   managed:
     roles:
       - name: balancer
         login: true
         passwordSecret:
           name: balancer-db-credentials
-
-  postgresql:
-    parameters:
-      shared_preload_libraries: 'vector'


### PR DESCRIPTION
## Summary

Fixes the `Cluster/shared-cluster` resource that's been rejected by the cnpg validating webhook since #135 deployed:

```
spec.postgresql.parameters.shared_preload_libraries: Invalid value: "vector":
  Can't set fixed configuration parameter
```

Two issues with that field: cnpg manages `shared_preload_libraries` itself (it's a "fixed" parameter, not user-settable through `parameters`), and pgvector doesn't actually need preloading — it loads on `CREATE EXTENSION vector;`. Drop the line entirely.

Also switches the operand image to one that has both PostGIS and pgvector baked in, and bumps the operator to support PG 18.

## Image choice

`ghcr.io/cloudnative-pg/postgis:18-3-system-trixie` — cnpg-maintained image. The `system` variant of the upstream postgresql base bundles a default extension set (verified via image config history):

```
ARG EXTENSIONS=postgresql-18-pgaudit postgresql-18-pgvector postgresql-18-pg-failover-slots
```

So this single image gives us PostGIS 3.6.3 + pgvector + pgaudit + pg-failover-slots + barman-cloud (for backups), all from the official cnpg image lineup. No custom Dockerfile needed.

## Operator bump

PG 18 requires cnpg ≥ 1.26. Bumping the chart from `cloudnative-pg-v0.23.1` (operator 1.25.0) to `cloudnative-pg-v0.28.0` (operator 1.29.0, latest GA, April 2026). No active Cluster CRs exist (the original was rejected and never created), so this is effectively a fresh install — no rolling-upgrade considerations.

## Validation

`kubectl diff -f infra/cloudnative-pg/shared-cluster.yaml` against the live cnpg 1.25 webhook returns exit 0 — the spec is now accepted (no more "Can't set fixed configuration parameter" rejection).

## Test plan

- [ ] `Build k8s-manifests` passes with the new chart
- [ ] Operator pod restarts onto v1.29.0 with no errors
- [ ] `Cluster/shared-cluster` is created in the cluster (no more webhook rejection)
- [ ] Three `shared-cluster-N` Postgres pods reach Ready
- [ ] In a `psql` shell on `shared-cluster-1`: `CREATE EXTENSION postgis; CREATE EXTENSION vector;` both succeed
- [ ] `Cluster` status `phase` reads `Cluster in healthy state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)