### PR TITLE
chore(cnpg): scale shared-cluster from 3 to 2 instances

### DIFF
--- a/infra/cloudnative-pg/shared-cluster.yaml
+++ b/infra/cloudnative-pg/shared-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: shared-cluster
   namespace: cloudnative-pg
 spec:
-  instances: 3
+  instances: 2
   imageName: ghcr.io/cloudnative-pg/postgis:18-3-system-trixie
   storage:
     size: 20Gi


### PR DESCRIPTION
## Summary

This sandbox runs low-demand workloads. Three Postgres instances is more redundancy than needed — drop to 2 (1 primary + 1 streaming replica), which still gives automated failover.

Saves a pod (~600Mi+ RAM), a 20Gi block storage PVC, and reduces the operator's reconcile surface.

## What happens on apply

cnpg will gracefully drain and remove `shared-cluster-3` (highest-numbered replica). The `-rw` Service still points at the primary; `-ro` and `-r` Services keep working with one less endpoint.

The `shared-cluster-3` PVC is retained because the storage class is `linode-block-storage-retain`. Can be deleted manually after the deploy if we don't want to keep it around.

## Validation

`kubectl diff` against the live cluster shows only the `instances: 3 → 2` change (plus the automatic `generation` bump). Webhook accepts cleanly.

## Test plan

- [ ] Deploy applies cleanly
- [ ] `kubectl -n cloudnative-pg get cluster shared-cluster` reads `2/2 Ready, Cluster in healthy state`
- [ ] `shared-cluster-3` pod removed; `shared-cluster-1` (primary) + `shared-cluster-2` (replica) remain
- [ ] Optional: clean up the orphaned `shared-cluster-3` PVC (`kubectl -n cloudnative-pg delete pvc shared-cluster-3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)