### PR TITLE
fix(deps): bump civic-cloud to v1.9.1 (cert-manager gate name)

### DIFF
--- a/.holo/sources/civic-cloud.toml
+++ b/.holo/sources/civic-cloud.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/civic-cloud/cluster-template"
-ref = "refs/tags/v1.9.0"
+ref = "refs/tags/v1.9.1"


### PR DESCRIPTION
## Summary

Picks up the cert-manager feature-gate-name fix from civic-cloud v1.9.1 (which pulls cluster-template v1.5.1).

v1.9.0 set the gate as `ListenerSet` (singular, per the cert-manager 1.20 release notes wording), but the actual gate name in cert-manager's controller code is `ListenerSets` (plural). The controller pod has been crash-looping in CrashLoopBackOff since the v1.9.0 deploy:

```
failed to set feature gates from initial flags-based config: unrecognized feature gate: ListenerSet
```

cert-manager's other components (webhook, cainjector) are unaffected. Existing Certificate resources don't need the controller until renewal time, so the cluster has been functional but unable to renew.

## Diff

One line in the rendered tree:

```diff
- ListenerSet: true
+ ListenerSets: true
```

Everything else from the v1.9.0 deploy stays.

## Test plan

- [ ] Deploy applies cleanly
- [ ] cert-manager controller pod transitions from CrashLoopBackOff → Running 1/1
- [ ] No `unrecognized feature gate` errors in controller logs after restart
- [ ] Smoke test: trigger renewal on echo-http-tls or similar; confirm new cert issued

🤖 Generated with [Claude Code](https://claude.com/claude-code)