### PR TITLE
feat(gateway-tls): force HTTP→HTTPS via global redirect HTTPRoute

### DIFF
--- a/_gateways/cfp-latest.yaml
+++ b/_gateways/cfp-latest.yaml
@@ -27,8 +27,6 @@ metadata:
   namespace: code-for-philly
 spec:
   parentRefs:
-    - name: main-gateway
-      namespace: envoy-gateway-system
     - name: latest
   hostnames:
     - latest.codeforphilly.sandbox.k8s.phl.io

--- a/_gateways/cfp-rewrite.yaml
+++ b/_gateways/cfp-rewrite.yaml
@@ -27,8 +27,6 @@ metadata:
   namespace: codeforphilly-rewrite-sandbox
 spec:
   parentRefs:
-    - name: main-gateway
-      namespace: envoy-gateway-system
     - name: codeforphilly
   hostnames:
     - codeforphilly-rewrite.codeforphilly.sandbox.k8s.phl.io

--- a/_gateways/choose-native-plants.yaml
+++ b/_gateways/choose-native-plants.yaml
@@ -27,8 +27,6 @@ metadata:
   namespace: choose-native-plants
 spec:
   parentRefs:
-    - name: main-gateway
-      namespace: envoy-gateway-system
     - name: choose-native-plants
   hostnames:
     - choose-native-plants.sandbox.k8s.phl.io

--- a/_gateways/echo-http.yaml
+++ b/_gateways/echo-http.yaml
@@ -27,8 +27,6 @@ metadata:
   namespace: echo-http
 spec:
   parentRefs:
-    - name: main-gateway
-      namespace: envoy-gateway-system
     - name: echo-http
   hostnames:
     - echo-http.sandbox.k8s.phl.io

--- a/_gateways/grafana.yaml
+++ b/_gateways/grafana.yaml
@@ -27,8 +27,6 @@ metadata:
   namespace: grafana
 spec:
   parentRefs:
-    - name: main-gateway
-      namespace: envoy-gateway-system
     - name: grafana
   hostnames:
     - metrics.sandbox.k8s.phl.io

--- a/_gateways/laddr-latest.yaml
+++ b/_gateways/laddr-latest.yaml
@@ -27,8 +27,6 @@ metadata:
   namespace: laddr
 spec:
   parentRefs:
-    - name: main-gateway
-      namespace: envoy-gateway-system
     - name: latest
   hostnames:
     - latest.laddr.sandbox.k8s.phl.io

--- a/_gateways/metabase.yaml
+++ b/_gateways/metabase.yaml
@@ -27,8 +27,6 @@ metadata:
   namespace: metabase
 spec:
   parentRefs:
-    - name: main-gateway
-      namespace: envoy-gateway-system
     - name: metabase
   hostnames:
     - metabase.sandbox.k8s.phl.io

--- a/_gateways/paws-data-pipeline.yaml
+++ b/_gateways/paws-data-pipeline.yaml
@@ -27,8 +27,6 @@ metadata:
   namespace: paws-data-pipeline
 spec:
   parentRefs:
-    - name: main-gateway
-      namespace: envoy-gateway-system
     - name: paws-data-pipeline
   # Only handle the wildcard-resolved hostname here; test.pawsdp.org is on
   # its own DNS zone still pointed at ingress-nginx, so it keeps working

--- a/_gateways/prevention-point.yaml
+++ b/_gateways/prevention-point.yaml
@@ -27,8 +27,6 @@ metadata:
   namespace: prevention-point
 spec:
   parentRefs:
-    - name: main-gateway
-      namespace: envoy-gateway-system
     - name: prevention-point
   hostnames:
     - prevention-point.sandbox.k8s.phl.io

--- a/_gateways/sealed-secrets.yaml
+++ b/_gateways/sealed-secrets.yaml
@@ -27,8 +27,6 @@ metadata:
   namespace: sealed-secrets
 spec:
   parentRefs:
-    - name: main-gateway
-      namespace: envoy-gateway-system
     - name: sealed-secrets
   hostnames:
     - sealed-secrets.sandbox.k8s.phl.io

--- a/_infra/envoy-gateway/http-redirect.yaml
+++ b/_infra/envoy-gateway/http-redirect.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-redirect
+  namespace: envoy-gateway-system
+spec:
+  parentRefs:
+    - name: main-gateway
+  # No hostnames → matches anything reaching main-gateway's HTTP listener.
+  # cert-manager's per-challenge HTTPRoute uses pathType: Exact on
+  # /.well-known/acme-challenge/<token> and a hostname filter — both more
+  # specific than this rule — so ACME validation traffic bypasses the
+  # redirect and reaches the solver Pod.
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301


### PR DESCRIPTION
## Summary

Adds a single redirect HTTPRoute attached to `main-gateway` that 301s all HTTP traffic to HTTPS. ACME challenge paths bypass the redirect because cert-manager's per-challenge HTTPRoute uses `pathType: Exact` on `/.well-known/acme-challenge/<token>` with a hostname match, beating the redirect's catch-all per [Gateway API conflict resolution](https://gateway-api.sigs.k8s.io/concepts/api-overview/#conflict-resolution).

Per-app HTTPRoutes drop their `main-gateway` parentRef since HTTP no longer needs to reach the backend — they attach only to their per-app HTTPS Gateway now.

## How it works

```
HTTP request to main-gateway (port 80)
  ├─ /.well-known/acme-challenge/<token> on <app>.sandbox.k8s.phl.io
  │   → matches cert-manager's HTTPRoute (Exact path + hostname filter)
  │   → solver pod responds with token
  │
  └─ everything else
      → matches http-redirect HTTPRoute (PathPrefix /, no hostname)
      → 301 to https://<host>/<path>
```

## Verification

Tested live on sandbox before opening:

- ✅ `curl -I http://echo-http.sandbox.k8s.phl.io/` → `301 Moved Permanently` → `https://echo-http...`
- ✅ Same for choose-native-plants, metrics (grafana), prevention-point
- ✅ `curl -I http://<host>/.well-known/acme-challenge/<token>` → `200 OK` (solver pod)
- ✅ The 4 pending certs that had been stuck in backoff issued cleanly after the redirect was applied (Exact match still wins as expected)

## Files

- `_infra/envoy-gateway/http-redirect.yaml` — new HTTPRoute
- `_gateways/*.yaml` — drop main-gateway from parentRefs (10 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)