### PR TITLE
chore(deps): bump civic-cloud to v1.9.2

### DIFF
--- a/.holo/sources/civic-cloud.toml
+++ b/.holo/sources/civic-cloud.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/civic-cloud/cluster-template"
-ref = "refs/tags/v1.9.1"
+ref = "refs/tags/v1.9.2"


### PR DESCRIPTION
## Summary

Bumps `civic-cloud` source to v1.9.2, which pulls in cluster-template v1.5.2 — removes hairpin-proxy from the LKE blueprint.

## Diff against deployed

```
 9 hairpin-proxy resources removed:
   _/ClusterRole/hairpin-proxy-controller-cr.yaml
   _/ClusterRoleBinding/hairpin-proxy-controller-crb.yaml
   _/Namespace/hairpin-proxy.yaml
   hairpin-proxy/Deployment/hairpin-proxy-controller.yaml
   hairpin-proxy/Deployment/hairpin-proxy-haproxy.yaml
   hairpin-proxy/Service/hairpin-proxy.yaml
   hairpin-proxy/ServiceAccount/hairpin-proxy-controller-sa.yaml
   kube-system/Role/hairpin-proxy-controller-r.yaml
   kube-system/RoleBinding/hairpin-proxy-controller-rb.yaml

 1 kube-system configmap removed:
   kube-system/ConfigMap/coredns-custom.yaml
```

The `coredns-custom` ConfigMap data was already cleared live during sandbox migration (hairpin-proxy-controller is at 0 replicas, so it's not maintaining rewrites anymore). The projected configmap removal lines up with that.

## Why

- **Linode LKE supports LoadBalancer hairpin natively** — verified by reaching `139.144.241.4` from inside a sandbox pod
- **hairpin-proxy was misrouting in-cluster requests** through ingress-nginx → app backends, bypassing the new Envoy data plane. This broke cert-manager HTTP-01 self-checks (resolved live by clearing `coredns-custom.hairpin-proxy.include` ahead of this PR landing).

## Status on live sandbox

- All 10 `*-gw-tls` certs Ready ✓
- All 10 HTTPS endpoints return expected statuses ✓
- HTTP → HTTPS redirect verified ✓
- hairpin-proxy-controller already scaled to 0
- After this deploys, the namespace and deployments fully drop out

🤖 Generated with [Claude Code](https://claude.com/claude-code)