### PR TITLE
chore(ingress-nginx): decommission and disable per-app Ingresses

### DIFF
--- a/.holo/branches/k8s-manifests/_civic-cloud.toml
+++ b/.holo/branches/k8s-manifests/_civic-cloud.toml
@@ -1,4 +1,8 @@
 [holomapping]
 holosource = "=>k8s-blueprint-lke"
-files = "**"
+files = [
+    "**",
+    "!ingress-nginx/**",
+    "!.holo/lenses/ingress-nginx.toml",
+]
 before = "*"

--- a/balancer/kustomization.yaml
+++ b/balancer/kustomization.yaml
@@ -7,29 +7,12 @@ resources:
   - manifests/namespace.yaml
   - manifests/deployment.yaml
   - manifests/service.yaml
-  - manifests/ingress.yaml
 
 images:
   - name: ghcr.io/codeforphilly/balancer-main/app
     newTag: "0.0.0-dev.20260211012449"
 
 patches:
-  - target:
-      kind: Ingress
-      name: balancer
-    patch: |-
-      - op: add
-        path: /metadata/annotations/cert-manager.io~1cluster-issuer
-        value: letsencrypt-prod
-      - op: add
-        path: /metadata/annotations/kubernetes.io~1ingress.class
-        value: nginx
-      - op: replace
-        path: /spec/tls/0/hosts/0
-        value: sandbox.balancerproject.org
-      - op: replace
-        path: /spec/rules/0/host
-        value: sandbox.balancerproject.org
   - target:
       kind: Namespace
       name: balancer

--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -28,14 +28,4 @@ resources:
 # (removed existingService and existingIngress configuration)
 
 ingress:
-  enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-  hosts:
-    - host: choose-native-plants.sandbox.k8s.phl.io
-      paths: [ '/' ]
-  tls:
-    - secretName: choose-native-plants-tls
-      hosts:
-        - choose-native-plants.sandbox.k8s.phl.io
+  enabled: false

--- a/echo-http.yaml
+++ b/echo-http.yaml
@@ -43,30 +43,3 @@ spec:
       targetPort: http
   selector:
     app: echo-http
-
----
-
-kind: Ingress
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: echo-http
-  namespace: echo-http
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    kubernetes.io/ingress.class: nginx
-spec:
-  tls:
-    - hosts:
-        - echo-http.sandbox.k8s.phl.io
-      secretName: echo-http-tls
-  rules:
-    - host: echo-http.sandbox.k8s.phl.io
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: echo-http
-                port:
-                  number: 80

--- a/grafana/release-values.yaml
+++ b/grafana/release-values.yaml
@@ -1,11 +1,10 @@
 # These values as applied last as downstream overrides
 # See https://github.com/grafana/helm-charts/blob/grafana-6.2.1/charts/grafana/values.yaml
 ingress:
+  enabled: false
 
-  enabled: true
-  hosts:
-    - metrics.sandbox.k8s.phl.io
-  tls:
-    - secretName: grafana-tls
-      hosts:
-        - metrics.sandbox.k8s.phl.io
+# Public hostname previously inferred from ingress.hosts. Set directly
+# now that the Ingress is gone (HTTPS is served by per-app Envoy Gateway).
+grafana.ini:
+  server:
+    domain: metrics.sandbox.k8s.phl.io

--- a/metabase/release-values.yaml
+++ b/metabase/release-values.yaml
@@ -25,6 +25,9 @@ configs:
     MB_DB_USER: metabase
     MB_DB_PASS: Qp8VX7I3rbFRs3s58ubi0rM9GQilaYFP
     MB_DB_HOST: database
+    # Public hostname previously inferred from ingress.hosts. Set directly
+    # now that the Ingress is gone (HTTPS is served by per-app Envoy Gateway).
+    MB_SITE_URL: https://metabase.sandbox.k8s.phl.io
 
 volumes:
   database:
@@ -32,14 +35,4 @@ volumes:
       size: 10Gi
 
 ingress:
-  enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-  hosts:
-    - host: metabase.sandbox.k8s.phl.io
-      paths: [ '/' ]
-  tls:
-    - secretName: metabase-tls
-      hosts:
-        - metabase.sandbox.k8s.phl.io
+  enabled: false

--- a/paws-data-pipeline/release-values.yaml
+++ b/paws-data-pipeline/release-values.yaml
@@ -1,17 +1,2 @@
 ingress:
-  enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-body-size: '50m'
-    nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
-  hosts:
-    - host: paws-data-pipeline.sandbox.k8s.phl.io
-      paths: [ '/' ]
-    - host: test.pawsdp.org
-      paths: [ '/' ]
-  tls:
-    - secretName: paws-data-pipeline-tls
-      hosts:
-        - paws-data-pipeline.sandbox.k8s.phl.io
-        - test.pawsdp.org
+  enabled: false

--- a/prevention-point/release-values.yaml
+++ b/prevention-point/release-values.yaml
@@ -5,14 +5,4 @@ frontend:
   image:
     tag: 0.3.3
 ingress:
-  enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-  hosts:
-    - host: prevention-point.sandbox.k8s.phl.io
-      paths: [ '/' ]
-  tls:
-    - secretName: prevention-point-tls
-      hosts:
-        - prevention-point.sandbox.k8s.phl.io
+  enabled: false

--- a/sealed-secrets/release-values.yaml
+++ b/sealed-secrets/release-values.yaml
@@ -2,9 +2,4 @@
 # See https://github.com/bitnami-labs/sealed-secrets/blob/main/helm/sealed-secrets/values.yaml
 
 ingress:
-  enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-  hostname: sealed-secrets.sandbox.k8s.phl.io
-  tls: true
+  enabled: false


### PR DESCRIPTION
## Summary

Removes ingress-nginx from the cluster now that all traffic flows through Envoy Gateway. Also disables per-app Ingresses so the deploy cleanup is one shot rather than leaving 8 orphans referencing a non-existent IngressClass.

Cluster-template upstream still ships ingress-nginx because other clusters need it during their own migrations. So the exclusion lives here per-cluster (via the `_civic-cloud.toml` `files` filter), not upstream.

## Changes

**`.holo/branches/k8s-manifests/_civic-cloud.toml`** — exclude ingress-nginx from the projection
- `!ingress-nginx/**` (helm chart source — drops the lens's input)
- `!.holo/lenses/ingress-nginx.toml` (the helm3 lens config — otherwise it errors trying to read the missing input root)

**Per-app Ingress disables (in this repo):**
- `choose-native-plants`, `grafana`, `metabase`, `paws-data-pipeline`, `prevention-point`, `sealed-secrets` — helm `ingress.enabled: false` in release-values
- `balancer/kustomization.yaml` — drop `manifests/ingress.yaml` resource + Ingress-targeting patch
- `echo-http.yaml` — remove the Ingress YAML doc
- `grafana`, `metabase` — also kept their public hostname configured explicitly (`grafana.ini.server.domain`, `MB_SITE_URL`) since both charts otherwise read it from `ingress.hosts[0]`

**Out of scope (managed by external CIs):**
- `code-for-philly/latest`, `laddr/latest` — emergence-site chart deployed by laddr's preview-deploy workflow
- `codeforphilly-rewrite-sandbox/codeforphilly` — rewrite project's own CI

Those Ingresses go orphan after this deploys (IngressClass `nginx` is gone). They're inert until each project's CI ships an update to stop creating them. Not urgent — DNS doesn't route there anymore.

## Projection diff vs deployed (27 deletions)

19 ingress-nginx resources:
```
_/ClusterRole/ingress-nginx{,-admission}.yaml
_/ClusterRoleBinding/ingress-nginx{,-admission}.yaml
_/Namespace/ingress-nginx.yaml
_/ValidatingWebhookConfiguration/ingress-nginx-admission.yaml
ingress-nginx/ConfigMap/ingress-nginx-controller.yaml
ingress-nginx/Deployment/ingress-nginx-controller.yaml
ingress-nginx/IngressClass/nginx.yaml
ingress-nginx/Job/ingress-nginx-admission-{create,patch}.yaml
ingress-nginx/Role/ingress-nginx{,-admission}.yaml
ingress-nginx/RoleBinding/ingress-nginx{,-admission}.yaml
ingress-nginx/Service/ingress-nginx-controller{,-admission}.yaml
ingress-nginx/ServiceAccount/ingress-nginx{,-admission}.yaml
```

8 per-app Ingresses:
```
balancer/Ingress/balancer.yaml
choose-native-plants/Ingress/choose-native-plants.yaml
echo-http/Ingress/echo-http.yaml
grafana/Ingress/grafana.yaml
metabase/Ingress/metabase.yaml
paws-data-pipeline/Ingress/paws-dp-chart.yaml
prevention-point/Ingress/prevention-point.yaml
sealed-secrets/Ingress/sealed-secrets.yaml
```

## Side effect

Deleting `ingress-nginx-controller` Service triggers Linode to free the LoadBalancer at `45.79.246.168` — was costing $10/mo with no inbound traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)