### PR TITLE
feat(balancer): clean design with shared-cluster cnpg + Envoy Gateway

### DIFF
--- a/.holo/branches/k8s-manifests/balancer/app/manifests.toml
+++ b/.holo/branches/k8s-manifests/balancer/app/manifests.toml
@@ -1,0 +1,11 @@
+[holomapping]
+holosource = "balancer"
+root = "deploy/manifests/balancer/base"
+files = [
+    "namespace.yaml",
+    "deployment.yaml",
+    "service.yaml",
+]
+# Excludes the upstream `ingress.yaml` (replaced by per-cluster
+# _gateways/balancer.yaml) and `kustomization.yaml` (we compose our
+# own at balancer/app/kustomization.yaml).

--- a/.holo/branches/k8s-manifests/balancer/manifests.toml
+++ b/.holo/branches/k8s-manifests/balancer/manifests.toml
@@ -1,4 +1,0 @@
-[holomapping]
-holosource = "balancer"
-root = "deploy/manifests/balancer/base"
-files = "**"

--- a/.holo/sources/balancer.toml
+++ b/.holo/sources/balancer.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/CodeForPhilly/balancer-main.git"
-ref = "refs/tags/v1.1.3"
+ref = "refs/tags/v1.1.5"

--- a/_gateways/balancer.yaml
+++ b/_gateways/balancer.yaml
@@ -1,0 +1,36 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: balancer
+  namespace: balancer
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  gatewayClassName: eg
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: balancer.sandbox.k8s.phl.io
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: balancer-gw-tls
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: balancer
+  namespace: balancer
+spec:
+  parentRefs:
+    - name: balancer
+  hostnames:
+    - balancer.sandbox.k8s.phl.io
+  rules:
+    - backendRefs:
+        - name: balancer
+          port: 8000

--- a/balancer/app/kustomization.yaml
+++ b/balancer/app/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: balancer
+
+resources:
+  - manifests/namespace.yaml
+  - manifests/deployment.yaml
+  - manifests/service.yaml
+
+images:
+  - name: ghcr.io/codeforphilly/balancer-main/app
+    newTag: "0.0.0-dev.20260211012449"

--- a/balancer/cnpg/database.yaml
+++ b/balancer/cnpg/database.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: balancer
+  namespace: cloudnative-pg
+spec:
+  name: balancer
+  owner: balancer
+  cluster:
+    name: shared-cluster

--- a/balancer/cnpg/kustomization.yaml
+++ b/balancer/cnpg/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# No namespace — database.yaml declares its own (cloudnative-pg). cnpg
+# requires the Database CR to live in the same namespace as the Cluster
+# it targets, so we keep it out of the balancer-app rewrite.
+resources:
+  - database.yaml

--- a/balancer/kustomization.yaml
+++ b/balancer/kustomization.yaml
@@ -1,22 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: balancer
-
+# No namespace here — each sub-kustomization sets its own:
+#   - app/ rewrites resources to `balancer`
+#   - cnpg/ leaves Database CR in its own `cloudnative-pg` namespace
+# kustomize emits a single stream; k8s-normalize routes by each
+# resource's metadata.namespace at deploy time.
 resources:
-  - manifests/namespace.yaml
-  - manifests/deployment.yaml
-  - manifests/service.yaml
-
-images:
-  - name: ghcr.io/codeforphilly/balancer-main/app
-    newTag: "0.0.0-dev.20260211012449"
-
-patches:
-  - target:
-      kind: Namespace
-      name: balancer
-    patch: |-
-      - op: replace
-        path: /metadata/name
-        value: dev
+  - app
+  - cnpg


### PR DESCRIPTION
## Summary

Restructures balancer to the clean design we settled on before going down the Envoy/Gateway rabbit hole. Now that all prereqs are in place (Gateway API CRDs, cert-manager 1.20 with gatewayHTTPRoute solver, hairpin-proxy gone), we can land it.

**Supersedes PR #143** (two-lens approach, ASCII sort-order hack, mutable `develop` source ref).

## What changes

### Workspace restructure

```
balancer/
├── kustomization.yaml          NEW — wrapper, resources: [app, cnpg], no namespace
├── app/
│   ├── kustomization.yaml      NEW — namespace: balancer, references mapped base
│   └── manifests/              (mapped from balancer-main base via hologit)
└── cnpg/
    ├── kustomization.yaml      NEW — no namespace
    └── database.yaml           NEW — Database CR in cloudnative-pg namespace
```

### Why this layout

- **Single hololens** — no `balancer-cnpg.toml`, no sort-order tricks
- **Database CR co-located** with the rest of balancer config, but its `metadata.namespace: cloudnative-pg` carries through. The cnpg sub-kustomization sets no namespace; k8s-normalize routes by resource at deploy time.
- **No upstream balancer-main#507 dependency** — the sandbox overlay (hostname, image tag, db hookup) lives in this repo where it belongs

### Hologit

- Source bumped `v1.1.3 → v1.1.5` (latest balancer-main release)
- Mapping moved to `.holo/branches/k8s-manifests/balancer/app/manifests.toml` (was `.../balancer/manifests.toml`)
- Mapping `files` filter explicitly enumerates `namespace.yaml`, `deployment.yaml`, `service.yaml` — drops the upstream `ingress.yaml` (replaced by `_gateways/balancer.yaml`) and the upstream `kustomization.yaml` (we compose our own)

### Gateway + HTTPRoute

Adds `_gateways/balancer.yaml` matching the per-app pattern from PR #152:
- Per-app `Gateway/balancer` with HTTPS listener on `balancer.sandbox.k8s.phl.io`
- `HTTPRoute/balancer` with parentRef only to the per-app Gateway (HTTP redirects globally via `_infra/envoy-gateway/http-redirect.yaml` from PR #154)
- `cert-manager.io/cluster-issuer: letsencrypt-prod` annotation → auto-issues `balancer-gw-tls`

Hostname matches what `balancer-main/deploy/manifests/balancer/base/secret.template.yaml` documents (`REACT_APP_API_BASE_URL: https://balancer.sandbox.k8s.phl.io/`) and aligns with the other sandbox apps.

## Diff vs deployed

```
A balancer/Gateway/balancer.yaml      (NEW)
A balancer/HTTPRoute/balancer.yaml    (NEW)
A cloudnative-pg/Database/balancer.yaml  (NEW)
```

Existing balancer Deployment, Service, Namespace, SealedSecret stay identical (same upstream content). No drift.

## Not in this PR (follow-ups)

1. **`balancer-db-credentials` SealedSecret** — the `shared-cluster` already has a `managed.roles[balancer]` entry pointing at this Secret name in `cloudnative-pg` namespace, but the Secret doesn't exist yet. cnpg has reconciled the role with an empty password. Needs a SealedSecret with a generated password.
2. **Database cutover** — balancer's `balancer-config` SealedSecret currently points `SQL_HOST` at an external RDS instance (`balancer-jj.cab6cwkqwif9.us-east-1.rds.amazonaws.com`). Migration to `shared-cluster-rw.cloudnative-pg.svc.cluster.local` requires data migration + coordinated SealedSecret update. This PR adds the empty target database; the cutover happens later.
3. **CORS / app config ConfigMap** — PR #143 was also adding a `balancer-db-config` ConfigMap and CORS env vars. Deferred to a follow-up after the DB cutover when the actual settings firm up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)