### PR TITLE
codeforphilly-ng: drop pvc-data; data is emptyDir now

### DIFF
--- a/.holo/branches/k8s-manifests/codeforphilly-ng/app/manifests.toml
+++ b/.holo/branches/k8s-manifests/codeforphilly-ng/app/manifests.toml
@@ -6,7 +6,6 @@ files = [
     "deployment.yaml",
     "service.yaml",
     "serviceaccount.yaml",
-    "pvc-data.yaml",
     "pvc-private.yaml",
 ]
 # Excludes the upstream `gateway.yaml` + `httproute.yaml` (replaced by

--- a/codeforphilly-ng/app/kustomization.yaml
+++ b/codeforphilly-ng/app/kustomization.yaml
@@ -9,5 +9,4 @@ resources:
   - manifests/deployment.yaml
   - manifests/service.yaml
   - manifests/serviceaccount.yaml
-  - manifests/pvc-data.yaml
   - manifests/pvc-private.yaml


### PR DESCRIPTION
## Summary

Cluster-side counterpart to [codeforphilly-ng#86](https://github.com/CodeForPhilly/codeforphilly-ng/pull/86), which eliminated the working tree on the pod's data clone. The upstream \`pvc-data.yaml\` manifest was deleted in that PR, so:

- \`.holo/branches/k8s-manifests/codeforphilly-ng/app/manifests.toml\` drops the now-missing file from the holomapping projection list.
- \`codeforphilly-ng/app/kustomization.yaml\` drops the corresponding resources reference so kubectl apply doesn't try to reach for a manifest that no longer exists upstream.

After this merges + the next k8s-manifests projection runs, the deployment's \`data\` volume becomes an \`emptyDir{}\` (already in the upstream deployment.yaml). A pod rollout-restart will mount the fresh emptyDir and the entrypoint bare-clones from origin on first boot.

## Test plan

- [ ] Project k8s-manifests; confirm \`codeforphilly-ng/app/manifests/pvc-data.yaml\` is gone from the projected tree
- [ ] \`kubectl apply -k cfp-sandbox-cluster/codeforphilly-ng/app/\` against sandbox succeeds
- [ ] Pod rollout-restart: pod boots, reaches \`/api/health/ready\` (200)
- [ ] Hot-reload webhook still works (push to data repo's \`published\` branch → pod logs the short-circuit / rebuild line)
- [ ] First-boot bare-clone time captured from entrypoint logs