### PR TITLE
feat(balancer): declare pgvector extension on the balancer database

### DIFF
--- a/balancer/cnpg/database.yaml
+++ b/balancer/cnpg/database.yaml
@@ -8,3 +8,9 @@ spec:
   owner: balancer
   cluster:
     name: shared-cluster
+  # Django's api.0005_embeddings migration creates a vector(384) column.
+  # cnpg-controller runs CREATE EXTENSION as postgres superuser; the `balancer`
+  # role lacks superuser perms so it can't enable extensions itself.
+  extensions:
+    - name: vector
+      ensure: present


### PR DESCRIPTION
## Summary

Makes the pgvector extension on the cnpg `balancer` database declarative via `Database.spec.extensions` (cnpg v1.27+ feature; we're on v1.29). Required for Django's `api.0005_embeddings` migration which creates a `vector(384)` column.

## Backstory

During the cutover deploy (#171/#173), the balancer pod tried to apply migrations against the freshly-bootstrapped cnpg database. Migration `api.0005_embeddings` failed with `type "vector" does not exist` because the extension was available cluster-wide but not enabled in the `balancer` database. The `balancer` role can't `CREATE EXTENSION` itself (lacks SUPERUSER), so we enabled it imperatively via the postgres superuser:

```bash
kubectl exec -n cloudnative-pg shared-cluster-1 -c postgres -- \
  psql -U postgres -d balancer -c "CREATE EXTENSION vector;"
```

After that, the pod restart applied all 12 pending migrations and 24 tables now exist in `public`. This PR captures that decision in GitOps so the configuration survives any rebuild.

## What changes

`balancer/cnpg/database.yaml`:

```yaml
spec:
  extensions:
    - name: vector
      ensure: present
```

cnpg-controller will reconcile this — the imperative `CREATE EXTENSION` we already ran satisfies the desired state, so the deploy is a no-op on the live cluster.

## Verification

- `kubectl diff` against live: only `generation: 1 → 2` + the new field; no other changes (cnpg is happy with the current state)
- Migration on next bootstrap of an empty balancer DB would have cnpg create the extension before Django starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)