### PR TITLE
Prepare sandbox for PlantAgents PostgreSQL sync

### DIFF
--- a/choose-native-plants/README.md
+++ b/choose-native-plants/README.md
@@ -39,6 +39,24 @@ The sandbox environment uses a GitOps approach for deployments. When you push ch
 
 ## Managing the Application
 
+### PlantAgents nursery data sync
+
+Create a read-only `plantagents-postgres` SealedSecret before enabling the weekly job:
+
+```powershell
+kubectl create secret generic plantagents-postgres --from-literal=PLANTAGENTS_DATABASE_URL='postgresql://...' --dry-run=client -o yaml > plantagents-postgres-secret.yaml
+kubeseal --cert https://sealed-secrets.sandbox.k8s.phl.io/v1/cert.pem --namespace choose-native-plants -f plantagents-postgres-secret.yaml -w cfp-sandbox-cluster/choose-native-plants.secrets/plantagents-postgres.yaml
+```
+
+Set `plantagentsSync.enabled: true`, deploy, and launch a one-off verification from the CronJob:
+
+```powershell
+kubectl create job --from=cronjob/choose-native-plants-plantagents-sync plantagents-sync-manual -n choose-native-plants
+kubectl logs -n choose-native-plants job/plantagents-sync-manual
+```
+
+The last log line is the JSON sync report. Verify `/api/v1/plantagents-sync-status` and representative nursery searches before enabling live.
+
 ### Syncing Images
 
 To sync images with the Linode Object Storage, use this command which automatically finds the current pod:

--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -10,8 +10,6 @@ app:
     - secretRef:
         name: mongo
     - secretRef:
-        name: pac-api
-    - secretRef:
         name: linode-storage
 
 # Resource settings for the application
@@ -28,4 +26,8 @@ resources:
 # (removed existingService and existingIngress configuration)
 
 ingress:
+  enabled: false
+
+# Enable after choose-native-plants.secrets/plantagents-postgres.yaml is sealed.
+plantagentsSync:
   enabled: false


### PR DESCRIPTION
## Summary
- remove legacy pac-api secret injection
- document the read-only Neon sealed secret and manual sync verification
- add disabled-by-default PlantAgents sync values