### PR TITLE
Deploy Choose Native Plants v2.3.2 to sandbox

### DIFF
--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -1,6 +1,6 @@
 app:
   image:
-    tag: "2.3.1"
+    tag: "2.3.2"
   env:
     - name: NODE_OPTIONS
       value: "--openssl-legacy-provider --max-old-space-size=3072"


### PR DESCRIPTION
Updates the Choose Native Plants sandbox image tag from 2.3.1 to 2.3.2.\n\nThe upstream v2.3.2 container publish workflow completed successfully.