### PR TITLE
Deploy Choose Native Plants v2.3.3 to sandbox

### DIFF
--- a/choose-native-plants/release-values.yaml
+++ b/choose-native-plants/release-values.yaml
@@ -1,6 +1,6 @@
 app:
   image:
-    tag: "2.3.2"
+    tag: "2.3.3"
   env:
     - name: NODE_OPTIONS
       value: "--openssl-legacy-provider --max-old-space-size=3072"


### PR DESCRIPTION
Updates the sandbox image from 2.3.2 to 2.3.3 to fix the nursery map regression. The tagged container image published successfully.