### PR TITLE
chore(balancer): pin to v1.1.7 tag and bump image off the dev build

### DIFF
--- a/.holo/sources/balancer.toml
+++ b/.holo/sources/balancer.toml
@@ -1,5 +1,7 @@
 [holosource]
 url = "https://github.com/CodeForPhilly/balancer-main.git"
-# Pinned to balancer-main#507 merge SHA (no tag has been cut past v1.1.5
-# yet). Move to a real tag whenever balancer-main publishes one >= v1.2.0.
-ref = "c88a4d8f580d9c701d832582fbf93b9e01c20004"
+
+# Pinned to a release tag, never a branch or a bare SHA. v1.1.7 contains the
+# balancer-main#507 merge (c88a4d8f) this was previously pinned to, plus the
+# HTTPRoute the app now owns.
+ref = "refs/tags/v1.1.7"

--- a/balancer/app/kustomization.yaml
+++ b/balancer/app/kustomization.yaml
@@ -23,4 +23,4 @@ generatorOptions:
 
 images:
   - name: ghcr.io/codeforphilly/balancer-main/app
-    newTag: "0.0.0-dev.20260211012449"
+    newTag: "1.1.7"


### PR DESCRIPTION
Closes the first two followups carried over from #162's closing comment, tracked in CodeForPhilly/balancer-main#526.

## What changed

**`.holo/sources/balancer.toml`** — `ref` moves from the bare SHA `c88a4d8f` (the balancer-main#507 merge) to `refs/tags/v1.1.7`.

The old comment said "no tag has been cut past v1.1.5 yet". That stopped being true on 2026-07-14. Both v1.1.6 and v1.1.7 contain the pinned commit:

```
$ gh api repos/CodeForPhilly/balancer-main/compare/c88a4d8f...v1.1.7 --jq .status,.behind_by
ahead
0
```

**`balancer/app/kustomization.yaml`** — image `0.0.0-dev.20260211012449` → `1.1.7`. That dev build is from Feb 11, months older than the June manifests it has been running under. `1.1.7` is published (verified against ghcr's manifest endpoint).

## Why this is safe

The pin bump is manifest-neutral. Everything that changed under `deploy/` between `c88a4d8f` and `v1.1.7`:

```
deploy/manifests/balancer/README.md
deploy/manifests/balancer/base/gateway-listeners.yaml
deploy/manifests/balancer/base/httproute.yaml
deploy/manifests/balancer/base/kustomization.yaml
deploy/manifests/balancer/overlays/production/kustomization.yaml
deploy/manifests/balancer/overlays/sandbox/kustomization.yaml
```

`balancer/app/manifests.toml` projects only `namespace.yaml`, `deployment.yaml` and `service.yaml` — none of those changed. Routing stays with this repo's `_gateways/balancer.yaml`; upstream's `httproute.yaml` is still not projected, so there is no duplicate route.

The image bump is the only behavioral change here, and it is the one worth eyes on.

## Verification after deploy

- `kubectl -n balancer get pods` → `1/1 Running`, no restarts
- `kubectl -n balancer get deploy balancer -o jsonpath='{.spec.template.spec.containers[0].image}'` → `...app:1.1.7`
- `curl -so /dev/null -w '%{http_code}' https://balancer.sandbox.k8s.phl.io/` → `200`, same for `/admin/login/`
- `kubectl -n cloudnative-pg get database balancer -o jsonpath='{.status.applied}'` → still `true`

## Not in this PR

The third followup in that comment — "the old RDS instance is now unused, coordinate to spin it down" — **should not be acted on.** It is true for sandbox only. `cfp-live-cluster` has no cnpg, and production's sealed `SQL_HOST` has not changed since 2025-12-06. See CodeForPhilly/balancer-main#526.
